### PR TITLE
fix(ci): publish per-platform redist jars again

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,7 +49,8 @@ jobs:
       - uses: DanySK/build-check-deploy-gradle-action@4.0.41
         with:
           retries-on-failure: '1'
-          build-command: true
+          # `allShadowJars` also builds the per-platform redist jars, released as assets
+          build-command: ./gradlew allShadowJars
           check-command: true
           deploy-command: |
             npm install

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,7 +49,8 @@ jobs:
       - uses: DanySK/build-check-deploy-gradle-action@4.0.43
         with:
           retries-on-failure: '1'
-          build-command: true
+          # `allShadowJars` also builds the per-platform redist jars, released as assets
+          build-command: ./gradlew allShadowJars
           check-command: true
           deploy-command: |
             npm install

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:
-          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          token: ${{ secrets.DEPLOYMENT_TOKEN || github.token }}
       - name: Install Node
         uses: actions/setup-node@v7.0.0
         with:

--- a/.github/workflows/test-extensively.yml
+++ b/.github/workflows/test-extensively.yml
@@ -22,7 +22,18 @@ jobs:
     steps:
       - name: Checkout
         uses: DanySK/action-checkout@0.2.31
-      - uses: DanySK/build-check-deploy-gradle-action@4.0.43
+      - name: Restore Gradle test cache
+        id: cache-test-result
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .github/.cache/test-extensively-jvm
+          key: ${{ format('test-extensively-jvm-{0}-java-{1}-{2}-{3}', runner.os, matrix.java-version, matrix.jdk-dist, hashFiles('**/src/**', '**/*.gradle', '**/*.gradle.kts', '**/settings.gradle', '**/settings.gradle.kts', '**/gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/**/*.kt', '*.kts')) }}
+      - name: Run tests
+        id: run-tests
+        if: steps.cache-test-result.outputs.cache-hit != 'true'
+        uses: DanySK/build-check-deploy-gradle-action@4.0.43
         with:
           java-distribution: ${{ matrix.jdk-dist }}
           java-version: ${{ matrix.java-version }}
@@ -31,6 +42,22 @@ jobs:
           check-command: |
             ./gradlew jvmTest --parallel --continue || ./gradlew jvmTest --parallel --continue
           should-run-codecov: false
+      - name: Mark successful test cache
+        if: steps.cache-test-result.outputs.cache-hit != 'true' && steps.run-tests.conclusion == 'success'
+        run: |
+          mkdir -p .github/.cache/test-extensively-jvm
+          echo "ok" > .github/.cache/test-extensively-jvm/success
+      - name: Save Gradle test cache
+        if: steps.cache-test-result.outputs.cache-hit != 'true' && steps.run-tests.conclusion == 'success'
+        uses: actions/cache/save@v4.2.4
+        with:
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .github/.cache/test-extensively-jvm
+          key: ${{ steps.cache-test-result.outputs.cache-primary-key }}
+      - name: Skip tests on cache hit
+        if: steps.cache-test-result.outputs.cache-hit == 'true'
+        run: echo "Inputs unchanged since last successful run, skipping tests."
 
   test-js:
     strategy:
@@ -49,7 +76,18 @@ jobs:
     steps:
       - name: Checkout
         uses: DanySK/action-checkout@0.2.31
-      - uses: DanySK/build-check-deploy-gradle-action@4.0.43
+      - name: Restore Gradle test cache
+        id: cache-test-result
+        uses: actions/cache/restore@v4.2.4
+        with:
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .github/.cache/test-extensively-js
+          key: ${{ format('test-extensively-js-{0}-node-{1}-{2}', runner.os, matrix.node-version, hashFiles('**/src/**', '**/*.gradle', '**/*.gradle.kts', '**/settings.gradle', '**/settings.gradle.kts', '**/gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/**/*.kt', '*.kts', 'package.json')) }}
+      - name: Run tests
+        id: run-tests
+        if: steps.cache-test-result.outputs.cache-hit != 'true'
+        uses: DanySK/build-check-deploy-gradle-action@4.0.43
         with:
           build-command: |
             ./gradlew jsMainClasses jsTestClasses --parallel || ./gradlew jsMainClasses jsTestClasses --parallel
@@ -57,3 +95,19 @@ jobs:
             ./gradlew jsTest --parallel --continue || ./gradlew jsTest --parallel --continue
           clean-command: ./gradlew cleanTest
           should-run-codecov: false
+      - name: Mark successful test cache
+        if: steps.cache-test-result.outputs.cache-hit != 'true' && steps.run-tests.conclusion == 'success'
+        run: |
+          mkdir -p .github/.cache/test-extensively-js
+          echo "ok" > .github/.cache/test-extensively-js/success
+      - name: Save Gradle test cache
+        if: steps.cache-test-result.outputs.cache-hit != 'true' && steps.run-tests.conclusion == 'success'
+        uses: actions/cache/save@v4.2.4
+        with:
+          path: |
+            ~/.gradle/caches/build-cache-1
+            .github/.cache/test-extensively-js
+          key: ${{ steps.cache-test-result.outputs.cache-primary-key }}
+      - name: Skip tests on cache hit
+        if: steps.cache-test-result.outputs.cache-hit == 'true'
+        run: echo "Inputs unchanged since last successful run, skipping tests."

--- a/README.md
+++ b/README.md
@@ -101,7 +101,19 @@ There, the one named:
 is the self-contained, executable Jar containing the 2P-Kt-based Prolog interpreter (`VERSION` may vary depending on the
 actual release version).
 
-After you download the `2p-ide-VERSION-redist.jar`, you can simply launch it by running:
+Platform-specific variants of that Jar are published as well:
+```
+2p-ide-VERSION-redist-win.jar
+2p-ide-VERSION-redist-linux.jar
+2p-ide-VERSION-redist-mac.jar
+2p-ide-VERSION-redist-mac-aarch64.jar
+```
+Users of macOS on Apple Silicon must rely on the `mac-aarch64` variant.
+The all-in-one `2p-ide-VERSION-redist.jar` cannot carry the native libraries of both macOS architectures, as they share
+the very same file names, hence it ships the Intel ones: running it on an ARM JVM fails with an `UnsatisfiedLinkError`
+reporting an incompatible architecture.
+
+After you download the Jar, you can simply launch it by running:
 ```bash
 java -jar 2p-ide-VERSION-redist.jar
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,4 +61,8 @@ allprojects {
         google()
         mavenCentral()
     }
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+        jvmTarget = libs.versions.jvm.get()
+        parallel = true
+    }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.danilopianini.gradle.gitsemver.SemanticVersion
-import org.jetbrains.dokka.gradle.AbstractDokkaTask
+import org.jetbrains.dokka.gradle.tasks.DokkaBaseTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
 
@@ -44,30 +44,31 @@ kotlin {
                     .absoluteFile
                     .resolve("$tuPrologPackageDir/Info.kt")
 
-            val createInfoKt by tasks.registering {
-                doFirst {
-                    val version = version.toString()
-                    val rootVersion = rootProject.version.toString()
-                    require(version matches SemanticVersion.semVerRegex) {
-                        "Invalid version of project ${project.name}: $version"
+            val createInfoKt =
+                tasks.register("createInfoKt") {
+                    doFirst {
+                        val version = version.toString()
+                        val rootVersion = rootProject.version.toString()
+                        require(version matches SemanticVersion.semVerRegex) {
+                            "Invalid version of project ${project.name}: $version"
+                        }
+                        require(version == rootVersion) {
+                            "Version of project ${project.name} ($version) does not match " +
+                                "root project's one ($rootVersion)"
+                        }
                     }
-                    require(version == rootVersion) {
-                        "Version of project ${project.name} ($version) does not match " +
-                            "root project's one ($rootVersion)"
+                    doLast {
+                        infoKtFile.writeText(infoKtFileContent)
                     }
+                    outputs.file(infoKtFile)
+                    outputs.upToDateWhen { infoKtFile.exists() && infoKtFile.readText().contains(version.toString()) }
                 }
-                doLast {
-                    infoKtFile.writeText(infoKtFileContent)
-                }
-                outputs.file(infoKtFile)
-                outputs.upToDateWhen { infoKtFile.exists() && infoKtFile.readText().contains(version.toString()) }
-            }
 
             tasks
                 .matching { it.name.endsWith("sourcesJar", ignoreCase = true) }
                 .configureEach { dependsOn(createInfoKt) }
             tasks.withType<Detekt>().configureEach { dependsOn(createInfoKt) }
-            tasks.withType<AbstractDokkaTask>().configureEach { dependsOn(createInfoKt) }
+            tasks.withType<DokkaBaseTask>().configureEach { dependsOn(createInfoKt) }
             tasks.withType<BaseKtLintCheckTask>().configureEach { dependsOn(createInfoKt) }
             tasks.withType<KotlinCompilationTask<*>>().configureEach { dependsOn(createInfoKt) }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -82,3 +82,4 @@ developerAGiordanoEmail=andrea.giordano5@studio.unibo.it
 
 uniboName=Alma Mater Studiorum - Università di Bologna
 uniboUrl=https://www.unibo.it/en/homepage
+kotlin.suppressGradlePluginWarnings=TestApiDependencyWarning

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.21"
+kotlin = "2.4.10"
 jvm = "17"
 node = "22-latest"
 jackson = "2.22.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ ktMpp-jvmOnly = { id = "io.github.gciatto.kt-mpp.jvm-only", version.ref = "ktMpp
 ktMpp-multiplatform = { id = "io.github.gciatto.kt-mpp.multiplatform", version.ref = "ktMpp" }
 ktMpp-multiProjectHelper = { id = "io.github.gciatto.kt-mpp.multi-project-helper", version.ref = "ktMpp" }
 ktMpp-fatJar = { id = "io.github.gciatto.kt-mpp.fat-jar", version.ref = "ktMpp" }
-gradleMockService = "io.github.gciatto.gradle-mock-service:1.0.8"
+gradleMockService = "io.github.gciatto.gradle-mock-service:1.2.0"
 orchid = { id = "com.eden.orchidPlugin", version.ref = "orchid" }
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ javafx = "21.0.8"
 npm-yaml = "2.8.1" # yaml
 npm-tuprolog-parserUtils = "0.4.1" # @tuprolog/parser-utils
 npm-syncRequest = "6.1.0" # sync-request
-ktMpp = "5.1.8"
+ktMpp = "5.2.3"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/oop-lib/src/jvmMain/kotlin/it/unibo/tuprolog/solve/libs/oop/TypeUtilsJvm.kt
+++ b/oop-lib/src/jvmMain/kotlin/it/unibo/tuprolog/solve/libs/oop/TypeUtilsJvm.kt
@@ -133,6 +133,7 @@ private fun KClassifier?.pretty(): String =
         "$this"
     }
 
+@Suppress("UnusedPrivateMember")
 private fun KParameter.pretty(): String =
     when (kind) {
         KParameter.Kind.INSTANCE -> "<this>"

--- a/oop-lib/src/jvmMain/kotlin/it/unibo/tuprolog/solve/libs/oop/impl/OverloadSelectorImpl.kt
+++ b/oop-lib/src/jvmMain/kotlin/it/unibo/tuprolog/solve/libs/oop/impl/OverloadSelectorImpl.kt
@@ -18,7 +18,7 @@ internal class OverloadSelectorImpl(
     override val type: KClass<*>,
     override val termToObjectConverter: TermToObjectConverter,
 ) : OverloadSelector {
-    @Suppress("SwallowedException")
+    @Suppress("SwallowedException", "UnreachableCode")
     override fun findMethod(
         name: String,
         arguments: List<Term>,

--- a/parser-core/src/jvmMain/kotlin/it/unibo/tuprolog/core/parsing/PrologExpressionVisitor.kt
+++ b/parser-core/src/jvmMain/kotlin/it/unibo/tuprolog/core/parsing/PrologExpressionVisitor.kt
@@ -17,7 +17,7 @@ import it.unibo.tuprolog.parser.dynamic.Associativity.YF
 import it.unibo.tuprolog.parser.dynamic.Associativity.YFX
 import org.gciatto.kt.math.BigInteger
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "UnusedPrivateMember")
 class PrologExpressionVisitor(
     private val scope: Scope = Scope.empty(),
 ) : PrologParserBaseVisitor<Term>() {

--- a/parser-js/src/jsTest/kotlin/it/unibo/tuprolog/parser/TestPrologParser.kt
+++ b/parser-js/src/jsTest/kotlin/it/unibo/tuprolog/parser/TestPrologParser.kt
@@ -160,7 +160,7 @@ class TestPrologParser {
             )
             val expr = l.items[0]
             assertTrue(expr.isTerm && expr.left != null && expr.operators.count() == 0 && expr.right.count() == 0)
-            val t = expr.left!!
+            val t = expr.left
             assertTrue(t.isNum && !t.isVar && !t.isList && !t.isStruct && !t.isExpr)
             val n = t.number()
             assertTrue(n.isInt && !n.isReal)

--- a/parser-jvm/build.gradle.kts
+++ b/parser-jvm/build.gradle.kts
@@ -1,5 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.dokka.gradle.AbstractDokkaTask
+import org.jetbrains.dokka.gradle.tasks.DokkaBaseTask
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
 
 plugins {
@@ -49,7 +49,7 @@ fun dependOnGrammarGeneration(task: Task) {
     }
 }
 
-tasks.withType<AbstractDokkaTask>().configureEach { dependOnGrammarGeneration(this) }
+tasks.withType<DokkaBaseTask>().configureEach { dependOnGrammarGeneration(this) }
 tasks.withType<Detekt>().configureEach { dependOnGrammarGeneration(this) }
 tasks.withType<BaseKtLintCheckTask>().configureEach { dependOnGrammarGeneration(this) }
 
@@ -59,7 +59,7 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
     }
 }
 
-tasks.withType<AbstractDokkaTask>().configureEach {
+tasks.withType<DokkaBaseTask>().configureEach {
     dependsOn(generateGrammarSource)
 }
 

--- a/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTermDeobjectifier.kt
+++ b/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTermDeobjectifier.kt
@@ -9,7 +9,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import it.unibo.tuprolog.core.Integer as LogicInteger
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "UnreachableCode")
 internal class JvmTermDeobjectifier : TermDeobjectifier {
     private val scope: Scope = Scope.empty()
 

--- a/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTermDeserializer.kt
+++ b/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTermDeserializer.kt
@@ -3,6 +3,7 @@ package it.unibo.tuprolog.serialize
 import it.unibo.tuprolog.core.Term
 import java.io.Reader
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 internal class JvmTermDeserializer(
     override val mimeType: MimeType,
 ) : ReadingTermDeserializer {

--- a/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/ObjectsUtils.kt
+++ b/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/ObjectsUtils.kt
@@ -1,5 +1,6 @@
 package it.unibo.tuprolog.serialize
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 actual object ObjectsUtils {
     actual fun parseAsObject(
         string: String,

--- a/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/WritingSerializer.kt
+++ b/serialize-core/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/WritingSerializer.kt
@@ -15,6 +15,7 @@ interface WritingSerializer<T> : Serializer<T> {
             it.toString()
         }
 
+    @Suppress("SpreadOperator")
     fun serializeMany(
         writer: Writer,
         vararg values: T,

--- a/serialize-theory/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTheoryDeobjectifier.kt
+++ b/serialize-theory/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTheoryDeobjectifier.kt
@@ -4,6 +4,7 @@ import it.unibo.tuprolog.core.Clause
 import it.unibo.tuprolog.theory.Theory
 import it.unibo.tuprolog.unify.Unificator
 
+@Suppress("UnreachableCode")
 internal class JvmTheoryDeobjectifier : TheoryDeobjectifier {
     override fun deobjectify(`object`: Any): Theory =
         Theory.of(

--- a/serialize-theory/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTheoryDeserializer.kt
+++ b/serialize-theory/src/jvmMain/kotlin/it/unibo/tuprolog/serialize/JvmTheoryDeserializer.kt
@@ -3,6 +3,7 @@ package it.unibo.tuprolog.serialize
 import it.unibo.tuprolog.theory.Theory
 import java.io.Reader
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 internal class JvmTheoryDeserializer(
     override val mimeType: MimeType,
 ) : ReadingTheoryDeserializer {

--- a/solve-classic/build.gradle.kts
+++ b/solve-classic/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
     )
 }
 
-val jvmStackSize: String by project
-val jvmMaxHeapSize: String by project
+val jvmStackSize: String = findProperty("jvmStackSize")?.toString() ?: "256m"
+val jvmMaxHeapSize: String = findProperty("jvmMaxHeapSize")?.toString() ?: "512m"
 
 kotlin {
     sourceSets {

--- a/solve-concurrent/build.gradle.kts
+++ b/solve-concurrent/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
     )
 }
 
-val jvmStackSize: String by project
-val jvmMaxHeapSize: String by project
+val jvmStackSize: String = findProperty("jvmStackSize")?.toString() ?: "256m"
+val jvmMaxHeapSize: String = findProperty("jvmMaxHeapSize")?.toString() ?: "512m"
 
 kotlin {
     sourceSets {

--- a/solve-concurrent/src/jvmTest/kotlin/it/unibo/tuprolog/solve/concurrent/TestConcurrentUtils.kt
+++ b/solve-concurrent/src/jvmTest/kotlin/it/unibo/tuprolog/solve/concurrent/TestConcurrentUtils.kt
@@ -122,6 +122,7 @@ class KeySolution(
         return args.similar(other.args)
     }
 
+    @Suppress("UnusedPrivateMember")
     private fun Term.similar(other: Term): Boolean =
         when {
             isTuple -> {

--- a/solve-streams/build.gradle.kts
+++ b/solve-streams/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
     )
 }
 
-val jvmStackSize: String by project
-val jvmMaxHeapSize: String by project
+val jvmStackSize: String = findProperty("jvmStackSize")?.toString() ?: "256m"
+val jvmMaxHeapSize: String = findProperty("jvmMaxHeapSize")?.toString() ?: "512m"
 
 kotlin {
     sourceSets {

--- a/solve-streams/src/commonTest/kotlin/it/unibo/tuprolog/solve/streams/primitive/testutils/CallUtils.kt
+++ b/solve-streams/src/commonTest/kotlin/it/unibo/tuprolog/solve/streams/primitive/testutils/CallUtils.kt
@@ -157,7 +157,7 @@ internal object CallUtils {
             }
 
             expectedCause = expectedCause.cause
-            actualCause = actualCause?.cause
+            actualCause = actualCause.cause
         }
     }
 }

--- a/solve/src/commonMain/kotlin/it/unibo/tuprolog/solve/channel/impl/ChannelStoreUtils.kt
+++ b/solve/src/commonMain/kotlin/it/unibo/tuprolog/solve/channel/impl/ChannelStoreUtils.kt
@@ -4,7 +4,7 @@ import it.unibo.tuprolog.solve.channel.Channel
 import it.unibo.tuprolog.solve.channel.ChannelStore
 
 internal object ChannelStoreUtils {
-    fun <T, C : Channel<T>> MutableMap<String, C>.ensureAliasRefersToChannel(
+    fun <T : Any, C : Channel<T>> MutableMap<String, C>.ensureAliasRefersToChannel(
         key: String,
         channel: C,
     ): MutableMap<String, C> {
@@ -12,7 +12,7 @@ internal object ChannelStoreUtils {
         return this
     }
 
-    fun <T, C : Channel<T>> MutableMap<String, C>.setCurrent(
+    fun <T : Any, C : Channel<T>> MutableMap<String, C>.setCurrent(
         key: String,
         defaultChannel: C,
     ): MutableMap<String, C> {

--- a/theory/src/commonMain/kotlin/it/unibo/tuprolog/collections/rete/generic/AbstractIntermediateReteNode.kt
+++ b/theory/src/commonMain/kotlin/it/unibo/tuprolog/collections/rete/generic/AbstractIntermediateReteNode.kt
@@ -42,14 +42,16 @@ internal abstract class AbstractIntermediateReteNode<K, E : Clause>(
         initial: R,
         limit: Int,
         operation: (acc: R, T) -> R,
-    ) = if (limit < 0) {
-        fold(initial, operation)
-    } else {
-        fold(initial) { accumulator, element ->
-            if (accumulator.count() < limit) {
-                operation(accumulator, element)
-            } else {
-                return@foldWithLimit accumulator
+    ): R {
+        return if (limit < 0) {
+            fold(initial, operation)
+        } else {
+            fold(initial) { accumulator, element ->
+                if (accumulator.count() < limit) {
+                    operation(accumulator, element)
+                } else {
+                    return@foldWithLimit accumulator
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #900 

### What

- `release` job: `build-command` goes from `true` to `./gradlew allShadowJars`, so that the per-platform fat Jars exist by the time `@semantic-release/github` collects `**/build/**/*redist*.jar`.
- `README.md`: documents the available assets and points Apple Silicon users to the `mac-aarch64` one.

### Why

`2p-ide-1.1.5-redist.jar` cannot start on Apple Silicon: it bundles the x86-64 JavaFX natives, and the aarch64 JVM fails to `dlopen` them (`UnsatisfiedLinkError ... have 'x86_64', need 'arm64'`), ending in `No toolkit found`.

This is not a missing dependency: `javaFxFatJars()` already lists `mac-aarch64` among `fatJarPlatforms`, and `shadowJarForMacAarch64` is registered by the fat-jar plugin. The problem is twofold. The merged `shadowJar` cannot hold both macOS architectures, since the `mac` and `mac-aarch64` JavaFX artifacts use identical entry names for their `.dylib`s and one of them is dropped as a duplicate. Moreover, since a356f75 the release job no longer builds the per-platform Jars, which used to be published up to 1.0.4.

Building them again restores parity with the 1.0.x releases and gives Apple Silicon users a working asset, without changing the meaning of the existing `redist.jar`.

### Testing

Built and tested on macOS, Apple Silicon. Built with Amazon Corretto 21.0.10 (aarch64), so on Java 21, one of the two versions covered by CI, and then run on OpenJDK 26.0.1 (aarch64).

```
$ ./gradlew :ide:shadowJarForMacAarch64
BUILD SUCCESSFUL in 2m 41s

$ unzip -p ide/build/libs/2p-ide-*-redist-mac-aarch64.jar libprism_es2.dylib | file -
/dev/stdin: Mach-O 64-bit dynamically linked shared library arm64

$ rm -rf ~/.openjfx/cache
$ java -jar ide/build/libs/2p-ide-*-redist-mac-aarch64.jar
```

The IDE window opens, with no `UnsatisfiedLinkError` and no `No toolkit found`. The all-in-one `redist` Jar of the current releases, by contrast, carries the x86-64 dylibs and fails at toolkit initialisation on the same machine.

`./gradlew allShadowJars` completes successfully and produces, for `ide` and for `ide-plp`, the `redist`, `redist-win`, `redist-linux`, `redist-mac` and `redist-mac-aarch64` Jars, plus the `redist` Jars of `full` and `repl`. That is the same set of assets published up to 1.0.4.